### PR TITLE
Update pubspec.yaml to prevent breaking changes

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -84,7 +84,7 @@ dependencies:
   quick_actions: ^1.0.6
   quiver: ^3.2.1
   recase: ^4.0.0
-  receive_sharing_intent: ^1.4.5
+  receive_sharing_intent: 1.4.5
   sentry_flutter: ^7.8.0
   share_plus: ^7.2.1
   shared_preferences: ^2.0.5


### PR DESCRIPTION
The library `receive_sharing_intent` had a breaking changes a week ago, and new builds are failing on GitJournal, hence removing `^` from deps versioning for this library https://pub.dev/packages/receive_sharing_intent
